### PR TITLE
Force imported banner on all G&S template pages

### DIFF
--- a/wp-content/themes/mojintranet/views/pages/guidance_and_support_content/main.php
+++ b/wp-content/themes/mojintranet/views/pages/guidance_and_support_content/main.php
@@ -13,7 +13,7 @@
       </nav>
     </div>
     <div class="col-lg-9 col-md-8 col-sm-12">
-      <?php if($is_imported): ?>
+      <?php if($is_imported||true): ?>
         <? $this->view('modules/imported_banner'); ?>
       <?php endif ?>
 


### PR DESCRIPTION
@marcincichon Can you review? JL & YD wanted the banner to appear on all G&S content pages. Didn't want to override the param in the controller in case it was/will be used elsewhere. Could potentially remove the if statements if this is a permanent fix.