### PR TITLE
Stop WP Document Revisions uploads being private by default

### DIFF
--- a/wp-content/themes/mojintranet/inc/uploads.php
+++ b/wp-content/themes/mojintranet/inc/uploads.php
@@ -9,3 +9,9 @@ function custom_upload_mimes ( $existing_mimes=array() ) {
   $existing_mimes['pot'] = 'application/pot';
   return $existing_mimes;
 }
+
+// Set documents uploaded via WP Document Revisions to be public by default
+add_filter( 'document_to_private', 'dont_make_private', 10, 2);
+function dont_make_private($post, $post_pre ){
+	return $post_pre;
+}


### PR DESCRIPTION
@marcincichon Can you review?