### PR TITLE
Bugfix: 292 Show the admin toolbar on frontend when logged in as an agency editor.

### DIFF
--- a/wp-content/themes/mojintranet/inc/user-management.php
+++ b/wp-content/themes/mojintranet/inc/user-management.php
@@ -2,7 +2,7 @@
 
 // Tweak admin bar for non-admins
 function hide_admin_bar_for_regular_users() {
-  if(!current_user_can('editor') && !current_user_can('administrator')) {
+  if (!current_user_can('agency-editor') && !current_user_can('editor') && !current_user_can('administrator')) {
     show_admin_bar(false);
   }
 }

--- a/wp-content/themes/mojintranet/inc/user-management.php
+++ b/wp-content/themes/mojintranet/inc/user-management.php
@@ -2,7 +2,7 @@
 
 // Tweak admin bar for non-admins
 function hide_admin_bar_for_regular_users() {
-  if (!current_user_can('agency-editor') && !current_user_can('editor') && !current_user_can('administrator')) {
+  if (!current_user_can('edit_pages')) {
     show_admin_bar(false);
   }
 }


### PR DESCRIPTION
Don't hide the admin bar if the user is an agency editor.

I've taken the opportunity to simplify this code so that anybody with permission to edit pages will see the admin bar. I've tested this against each of the user roles we use, and this behaves as expected:

- Administrators, Global Editors, Agency Editors all see the admin bar.
- Subscribers do not.

@marcincichon @RobertWDLowe please review?