### PR TITLE
Hide Quick Edit Categories

### DIFF
--- a/wp-content/themes/mojintranet/admin/css/personalisation.css
+++ b/wp-content/themes/mojintranet/admin/css/personalisation.css
@@ -7,7 +7,7 @@
     padding: 5px;
 }
 
-.agency-checklist,
+.agency-checklist, .inline-edit-categories,
 .inline-edit-row fieldset span.inline-edit-categories-label:nth-child(4) {
     display: none;
 }


### PR DESCRIPTION
A bug was found that you can edit resource and news categories via quick edit.

The issue here is that you cant filter the terms by agency. 

So we are hiding category editing on quick editing. Its abit of a general hide. Mainly as the labels do not use unique classes per taxonomy on the quick edit screen.

As it stands anyway we only have the following taxonomies:

Resource Categories: Shouldn't be on quick edit
News Categories: Shouldn't be on quick edit
Categories : Not used
Agencies: Shouldn't be on quick edit


@ollietreend  please review.
