### PR TITLE
456 post nav

### DIFF
--- a/wp-content/themes/mojintranet/assets/css/src/modules/_content_nav.scss
+++ b/wp-content/themes/mojintranet/assets/css/src/modules/_content_nav.scss
@@ -2,6 +2,10 @@
   @extend %larger-copy;
   @include clearfix;
 
+  &.nav-hidden {
+    display: none;
+  }
+
   li {
     &:before,
     &:after {

--- a/wp-content/themes/mojintranet/assets/js/src/init.js
+++ b/wp-content/themes/mojintranet/assets/js/src/init.js
@@ -18,6 +18,7 @@ jQuery(function() {
   //App.ins.childrenPages = new App.ChildrenPages();
   App.ins.tabbedContent = new App.TabbedContent();
   App.ins.news = new App.News();
+  App.ins.singleNews = new App.SingleNews();
   App.ins.blog = new App.Blog();
   App.ins.events = new App.Events();
   App.ins.comments = new App.Comments();

--- a/wp-content/themes/mojintranet/assets/js/src/init.js
+++ b/wp-content/themes/mojintranet/assets/js/src/init.js
@@ -20,6 +20,7 @@ jQuery(function() {
   App.ins.news = new App.News();
   App.ins.singleNews = new App.SingleNews();
   App.ins.blog = new App.Blog();
+  App.ins.blogPost = new App.BlogPost();
   App.ins.events = new App.Events();
   App.ins.comments = new App.Comments();
   App.ins.shareViaEmail = new App.ShareViaEmail();

--- a/wp-content/themes/mojintranet/assets/js/src/modules/blog.js
+++ b/wp-content/themes/mojintranet/assets/js/src/modules/blog.js
@@ -20,7 +20,7 @@
       };
 
       this.applicationUrl = $('head').data('application-url');
-      this.serviceUrl = this.applicationUrl+'/service/post';
+      this.serviceUrl = this.applicationUrl+'/service/post/get';
       this.pageBase = this.applicationUrl+'/'+this.$top.data('top-level-slug');
 
       this.itemTemplate = this.$top.find('[data-name="blog-item"]').html();

--- a/wp-content/themes/mojintranet/assets/js/src/modules/blog_post.js
+++ b/wp-content/themes/mojintranet/assets/js/src/modules/blog_post.js
@@ -40,16 +40,21 @@
     },
 
     displayNavLinks: function(data) {
-        if(data.prev_link.length > 0) {
-          $( ".previous .nav-label" ).wrap(function() {
-            return $('<a/>').attr("href", data.prev_link).attr("aria-labelledby", 'prev-page-label');
-          });
-        }
-        if(data.next_link.length > 0) {
-          $( ".next .nav-label" ).wrap(function() {
-            return $('<a/>').attr("href", data.next_link).attr("aria-labelledby", 'next-page-label');
-          });
-        }
+      if(data.prev_link.length > 0) {
+        $(".previous a").attr("href", data.prev_link);
+      }
+      else {
+        $(".previous").html($(".previous a").html());
+      }
+
+      if(data.next_link.length > 0) {
+        $( ".next a" ).attr("href", data.next_link);
+      }
+      else {
+        $(".next").html($(".next a").html());
+      }
+
+      $(".content-nav").removeClass('nav-hidden');
     },
 
     getDataObject: function() {

--- a/wp-content/themes/mojintranet/assets/js/src/modules/blog_post.js
+++ b/wp-content/themes/mojintranet/assets/js/src/modules/blog_post.js
@@ -1,20 +1,20 @@
-/** Single News
+/** Blog Post
  */
 (function($) {
   "use strict";
 
   var App = window.App;
 
-  App.SingleNews = function() {
-    this.$top = $('.template-single-news .template-container');
+  App.BlogPost = function() {
+    this.$top = $('.template-blog-post .template-container');
     if(!this.$top.length) { return; }
     this.init();
   };
 
-  App.SingleNews.prototype = {
+  App.BlogPost.prototype = {
     init: function() {
       this.applicationUrl = $('head').data('application-url');
-      this.serviceUrl = this.applicationUrl+'/service/news/siblings';
+      this.serviceUrl = this.applicationUrl+'/service/post/siblings';
 
       this.loadNavLinks();
     },

--- a/wp-content/themes/mojintranet/assets/js/src/modules/news.js
+++ b/wp-content/themes/mojintranet/assets/js/src/modules/news.js
@@ -20,7 +20,7 @@
       };
 
       this.applicationUrl = $('head').data('application-url');
-      this.serviceUrl = this.applicationUrl+'/service/news';
+      this.serviceUrl = this.applicationUrl+'/service/news/get';
       this.pageBase = this.applicationUrl+'/'+this.$top.data('top-level-slug');
 
       this.itemTemplate = this.$top.find('.template-partial[data-name="news-item"]').html();

--- a/wp-content/themes/mojintranet/assets/js/src/modules/single_news.js
+++ b/wp-content/themes/mojintranet/assets/js/src/modules/single_news.js
@@ -40,16 +40,21 @@
     },
 
     displayNavLinks: function(data) {
-        if(data.prev_link.length > 0) {
-          $( ".previous .nav-label" ).wrap(function() {
-            return $('<a/>').attr("href", data.prev_link).attr("aria-labelledby", 'prev-page-label');
-          });
-        }
-        if(data.next_link.length > 0) {
-          $( ".next .nav-label" ).wrap(function() {
-            return $('<a/>').attr("href", data.next_link).attr("aria-labelledby", 'next-page-label');
-          });
-        }
+      if(data.prev_link.length > 0) {
+        $(".previous a").attr("href", data.prev_link);
+      }
+      else {
+        $(".previous").html($(".previous a").html());
+      }
+
+      if(data.next_link.length > 0) {
+        $( ".next a" ).attr("href", data.next_link);
+      }
+      else {
+        $(".next").html($(".next a").html());
+      }
+
+      $(".content-nav").removeClass('nav-hidden');
     },
 
     getDataObject: function() {

--- a/wp-content/themes/mojintranet/assets/js/src/modules/single_news.js
+++ b/wp-content/themes/mojintranet/assets/js/src/modules/single_news.js
@@ -1,0 +1,70 @@
+/** News
+ */
+(function($) {
+  "use strict";
+
+  var App = window.App;
+
+  App.SingleNews = function() {
+    this.$top = $('.template-single-news .template-container');
+    if(!this.$top.length) { return; }
+    this.init();
+  };
+
+  App.SingleNews.prototype = {
+    init: function() {
+
+      this.applicationUrl = $('head').data('application-url');
+      this.serviceUrl = this.applicationUrl+'/service/news/siblings';
+
+      this.loadNavLinks();
+    },
+
+    loadNavLinks: function() {
+
+      this.postID = $('.template-container').data('post-id');
+
+      if ($.isNumeric(this.postID)) {
+        var requestData = this.getDataObject();
+        this.requestNavLinks(requestData);
+      }
+    },
+
+    requestNavLinks: function(data) {
+      var _this = this;
+      var dataArray = [];
+
+      $.each(data, function(key, value) {
+        dataArray.push(value);
+      });
+
+      _this.serviceXHR = $.getJSON(_this.serviceUrl+'/'+dataArray.join('/'), $.proxy(_this.displayNavLinks, _this));
+
+    },
+
+    displayNavLinks: function(data) {
+        if(data.prev_link.length > 0) {
+          $( ".previous .nav-label" ).wrap(function() {
+            return $('<a/>').attr("href", data.prev_link).attr("aria-labelledby", 'prev-page-label');
+          });
+        }
+        if(data.next_link.length > 0) {
+          $( ".next .nav-label" ).wrap(function() {
+            return $('<a/>').attr("href", data.next_link).attr("aria-labelledby", 'next-page-label');
+          });
+        }
+    },
+
+    getDataObject: function() {
+
+      var base = {
+        'agency': App.tools.helpers.agency.getForContent(),
+        'additional_filters': '',
+        'post_id': this.postID,
+      };
+
+      return base;
+    },
+
+  };
+}(jQuery));

--- a/wp-content/themes/mojintranet/models/post_siblings.php
+++ b/wp-content/themes/mojintranet/models/post_siblings.php
@@ -1,0 +1,84 @@
+<?php if (!defined('ABSPATH')) die();
+
+class Post_siblings_model extends MVC_model {
+
+  /** Get a previous and next links for a post object
+   * @param {Array} $options Options and filters (see search model for details)
+   * @return {Array} Formatted and sanitized results
+   */
+  public function get_post_sibling_links($options = array()) {
+    $this->current_agency = $options['agency'] ?: 'hq';
+
+    if (is_numeric($options['post_id'])) {
+      global $post;
+      $data = [
+          'prev_link' => '',
+          'next_link' => '',
+      ];
+
+      $post = get_post($options['post_id']);
+
+      if (is_null($post) == false) {
+        setup_postdata($post);
+
+        add_filter('get_next_post_join', array($this, 'navigate_in_same_agency_join'), 20);
+        add_filter('get_previous_post_join', array($this, 'navigate_in_same_agency_join'), 20);
+
+        add_filter('get_next_post_where' , array($this, 'navigate_in_same_agency_where'));
+        add_filter('get_previous_post_where' , array($this, 'navigate_in_same_agency_where'));
+
+        $prev_post = get_previous_post();
+
+        if (is_object($prev_post)) {
+          $data['prev_link'] = get_permalink($prev_post->ID);
+        }
+
+        $next_post = get_next_post();
+
+        if (is_object($next_post)) {
+          $data['next_link'] = get_permalink($next_post->ID);
+        }
+
+        wp_reset_postdata();
+      }
+    }
+
+    return $data;
+
+  }
+
+  public function navigate_in_same_agency_join() {
+    global $wpdb;
+    return " INNER JOIN $wpdb->term_relationships AS tr ON p.ID = tr.object_id INNER JOIN $wpdb->term_taxonomy tt ON tr.term_taxonomy_id = tt.term_taxonomy_id";
+  }
+
+  public function navigate_in_same_agency_where($original) {
+    global $wpdb, $post;
+
+    $agency_term = get_term_by('slug', $this->current_agency, 'agency');
+
+    if ( ! $agency_term )
+      return $original ;
+
+    $where 	= '';
+    $taxonomy = 'agency';
+    $op = ('get_previous_post_where' == current_filter()) ? '<' : '>';
+    $where = $wpdb->prepare( "AND tt.taxonomy = %s", $taxonomy );
+
+    if ( ! is_object_in_taxonomy( $post->post_type, $taxonomy ) )
+      return $original ;
+
+    $where 	= " AND tt.term_id = " . $agency_term->term_id;
+    return $wpdb->prepare("WHERE p.post_date $op %s AND p.post_type = %s AND p.post_status = 'publish' $where", $post->post_date, $post->post_type);
+  }
+
+}
+
+
+
+
+
+
+
+
+

--- a/wp-content/themes/mojintranet/models/post_siblings.php
+++ b/wp-content/themes/mojintranet/models/post_siblings.php
@@ -73,12 +73,3 @@ class Post_siblings_model extends MVC_model {
   }
 
 }
-
-
-
-
-
-
-
-
-

--- a/wp-content/themes/mojintranet/modules/api/news.php
+++ b/wp-content/themes/mojintranet/modules/api/news.php
@@ -1,4 +1,3 @@
-
 <?php if (!defined('ABSPATH')) die();
 
 /** News API

--- a/wp-content/themes/mojintranet/modules/api/news.php
+++ b/wp-content/themes/mojintranet/modules/api/news.php
@@ -1,3 +1,4 @@
+
 <?php if (!defined('ABSPATH')) die();
 
 /** News API
@@ -7,14 +8,25 @@
 class News_API extends API {
   public function __construct($params) {
     parent::__construct();
+    $this->MVC->model('post_siblings');
     $this->parse_params($params);
     $this->route();
   }
 
   protected function route() {
+    $method = $this->get_param('method');
+
     switch ($this->get_method()) {
       case 'GET':
-        $this->get_news();
+        switch ($method) {
+          case 'get':
+            $this->get_news();
+            break;
+
+          case 'siblings':
+            $this->get_sibling_links();
+            break;
+        }
         break;
 
       default:
@@ -23,14 +35,24 @@ class News_API extends API {
   }
 
   protected function parse_params($params) {
+    $method = $params[0];
+
     $this->params = array(
-      'agency' => $params[0],
-      'additional_params' => $params[1],
-      'date' => $params[2],
-      'keywords' => $params[3],
-      'page' => $params[4] ?: 1,
-      'per_page' => $params[5] ?: 10
+        'method' => $method,
     );
+
+    $this->params['agency'] = $params[1];
+    $this->params['additional_params'] = $params[2];
+
+    if ($method == 'get') {
+      $this->params['date'] = $params[3];
+      $this->params['keywords'] = $params[4];
+      $this->params['page'] = $params[5];
+      $this->params['per_page'] = $params[6] ?: 10;
+    }
+    else if ($method == 'siblings'){
+      $this->params['post_id'] = $params[3];
+    }
   }
 
   protected function get_news() {
@@ -38,6 +60,12 @@ class News_API extends API {
     $options = $this->add_taxonomies($options);
     $data = $this->MVC->model->news->get_list($options);
     $data['url_params'] = $this->params;
+    $this->response($data, 200, 300);
+  }
+
+  protected function get_sibling_links() {
+    $options = $this->params;
+    $data = $this->MVC->model->post_siblings->get_post_sibling_links($options);
     $this->response($data, 200, 300);
   }
 }

--- a/wp-content/themes/mojintranet/modules/api/post.php
+++ b/wp-content/themes/mojintranet/modules/api/post.php
@@ -7,14 +7,25 @@
 class Post_API extends API {
   public function __construct($params) {
     parent::__construct();
+    $this->MVC->model('post_siblings');
     $this->parse_params($params);
     $this->route();
   }
 
   protected function route() {
+    $method = $this->get_param('method');
+
     switch ($this->get_method()) {
       case 'GET':
-        $this->get_posts();
+        switch ($method) {
+          case 'get':
+            $this->get_posts();
+            break;
+
+          case 'siblings':
+            $this->get_sibling_links();
+            break;
+        }
         break;
 
       default:
@@ -23,14 +34,25 @@ class Post_API extends API {
   }
 
   protected function parse_params($params) {
+    $method = $params[0];
+
     $this->params = array(
-      'agency' => $params[0],
-      'additional_filters' => $params[1],
-      'date' => $params[2],
-      'keywords' => $params[3],
-      'page' => $params[4] ?: 1,
-      'per_page' => $params[5] ?: 10
+        'method' => $method,
     );
+
+    $this->params['agency'] = $params[1];
+    $this->params['additional_params'] = $params[2];
+
+    if ($method == 'get') {
+      $this->params['date'] = $params[3];
+      $this->params['keywords'] = $params[4];
+      $this->params['page'] = $params[5];
+      $this->params['per_page'] = $params[6] ?: 10;
+    }
+    else if ($method == 'siblings'){
+      $this->params['post_id'] = $params[3];
+    }
+
   }
 
   protected function get_posts() {
@@ -40,4 +62,11 @@ class Post_API extends API {
     $data['url_params'] = $this->params;
     $this->response($data, 200, 300);
   }
+
+  protected function get_sibling_links() {
+    $options = $this->params;
+    $data = $this->MVC->model->post_siblings->get_post_sibling_links($options);
+    $this->response($data, 200, 300);
+  }
+
 }

--- a/wp-content/themes/mojintranet/single-news.php
+++ b/wp-content/themes/mojintranet/single-news.php
@@ -15,14 +15,11 @@ class Single_news extends MVC_controller {
     the_content();
     $content = ob_get_clean();
 
-    $this_id = $post->ID;
+    $this_id = get_the_ID();
 
     $thumbnail_id = get_post_thumbnail_id($this_id);
     $thumbnail = wp_get_attachment_image_src($thumbnail_id, 'intranet-large');
     $alt_text = get_post_meta($thumbnail_id, '_wp_attachment_image_alt', true);
-
-    $prev_news = get_previous_post();
-    $next_news = get_next_post();
 
     return array(
       'page' => 'pages/news_single/main',
@@ -39,10 +36,6 @@ class Single_news extends MVC_controller {
         'content' => $content,
         'raw_date' => $article_date,
         'human_date' => date("j F Y", strtotime($article_date)),
-        'prev_news_exists' => is_object($prev_news),
-        'next_news_exists' => is_object($next_news),
-        'prev_news_url' => get_post_permalink($prev_news),
-        'next_news_url' => get_post_permalink($next_news),
         'election_banner' => array(
           'visible' => strtotime($article_date) < strtotime('9 May 2015')?1:0
         )

--- a/wp-content/themes/mojintranet/single-post.php
+++ b/wp-content/themes/mojintranet/single-post.php
@@ -45,10 +45,6 @@ class Single_post extends MVC_controller {
         'content' => $content,
         'raw_date' => $article_date,
         'human_date' => date("j F Y", strtotime($article_date)),
-        'prev_post_exists' => is_object($prev_post),
-        'next_post_exists' => is_object($next_post),
-        'prev_post_url' => get_post_permalink($prev_post),
-        'next_post_url' => get_post_permalink($next_post),
         'share_email_body' => "Hi there,\n\nI thought you might be interested in this blog post I've found on the MoJ intranet:\n",
         'likes_count' => $likes['count']
       )

--- a/wp-content/themes/mojintranet/views/pages/blog_post/main.php
+++ b/wp-content/themes/mojintranet/views/pages/blog_post/main.php
@@ -44,31 +44,15 @@
 
       <ul class="content-nav grid">
         <li class="previous col-lg-6 col-md-6 col-sm-6">
-          <?php if($prev_post_exists): ?>
-            <a href="<?=$prev_post_url?>" aria-labelledby="prev-page-label">
-              <span class="nav-label" id="prev-page-label">
-                Previous
-              </span>
-            </a>
-          <?php else: ?>
-            <span class="nav-label">
+            <span class="nav-label"  id="prev-page-label">
               Previous
             </span>
-          <?php endif ?>
         </li>
 
         <li class="next col-lg-6 col-md-6 col-sm-6">
-          <?php if($next_post_exists): ?>
-            <a href="<?=$next_post_url?>" aria-labelledby="next-page-label">
-              <span class="nav-label" id="next-page-label">
-                Next
-              </span>
-            </a>
-          <?php else: ?>
-            <span class="nav-label">
+            <span class="nav-label" id="next-page-label">
               Next
             </span>
-          <?php endif ?>
         </li>
       </ul>
     </div>

--- a/wp-content/themes/mojintranet/views/pages/blog_post/main.php
+++ b/wp-content/themes/mojintranet/views/pages/blog_post/main.php
@@ -42,17 +42,21 @@
 
       </div>
 
-      <ul class="content-nav grid">
+      <ul class="content-nav nav-hidden grid">
         <li class="previous col-lg-6 col-md-6 col-sm-6">
+          <a href="" aria-labelledby="prev-page-label">
             <span class="nav-label"  id="prev-page-label">
               Previous
             </span>
+          </a>
         </li>
 
         <li class="next col-lg-6 col-md-6 col-sm-6">
+          <a href="" aria-labelledby="next-page-label">
             <span class="nav-label" id="next-page-label">
               Next
             </span>
+          </a>
         </li>
       </ul>
     </div>

--- a/wp-content/themes/mojintranet/views/pages/news_single/main.php
+++ b/wp-content/themes/mojintranet/views/pages/news_single/main.php
@@ -46,17 +46,21 @@
         <?=$content?>
       </div>
 
-      <ul class="content-nav grid">
+      <ul class="content-nav nav-hidden grid">
         <li class="previous col-lg-6 col-md-6 col-sm-6">
-          <span class="nav-label" id="prev-page-label">
-            Previous
-          </span>
+          <a href="" aria-labelledby="prev-page-label">
+            <span class="nav-label" id="prev-page-label">
+              Previous
+            </span>
+          </a>
         </li>
 
         <li class="next col-lg-6 col-md-6 col-sm-6">
-          <span class="nav-label" id="next-page-label">
-            Next
-          </span>
+          <a href="" aria-labelledby="next-page-label">
+            <span class="nav-label" id="next-page-label">
+              Next
+            </span>
+          </a>
         </li>
       </ul>
     </div>

--- a/wp-content/themes/mojintranet/views/pages/news_single/main.php
+++ b/wp-content/themes/mojintranet/views/pages/news_single/main.php
@@ -1,6 +1,6 @@
 <?php if (!defined('ABSPATH')) die(); ?>
 
-<div class="template-container">
+<div class="template-container" data-post-id="<?=$id?>">
   <?php $this->view('pages/news_single/election_banner', $election_banner) ?>
 
   <div class="grid">
@@ -48,31 +48,15 @@
 
       <ul class="content-nav grid">
         <li class="previous col-lg-6 col-md-6 col-sm-6">
-          <?php if($prev_news_exists): ?>
-            <a href="<?=$prev_news_url?>" aria-labelledby="prev-page-label">
-              <span class="nav-label" id="prev-page-label">
-                Previous
-              </span>
-            </a>
-          <?php else: ?>
-            <span class="nav-label">
-              Previous
-            </span>
-          <?php endif ?>
+          <span class="nav-label" id="prev-page-label">
+            Previous
+          </span>
         </li>
 
         <li class="next col-lg-6 col-md-6 col-sm-6">
-          <?php if($next_news_exists): ?>
-            <a href="<?=$next_news_url?>" aria-labelledby="next-page-label">
-              <span class="nav-label" id="next-page-label">
-                Next
-              </span>
-            </a>
-          <?php else: ?>
-            <span class="nav-label">
-              Next
-            </span>
-          <?php endif ?>
+          <span class="nav-label" id="next-page-label">
+            Next
+          </span>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
Post Nav Fix:

Next and prev links now load through JS.

@ollietreend  and @marcincichon  please review
To confirm:

1. Are we happy that the service apis are now called get method? E.g.
http://www.moj-intranet.com/service/news/get
http://www.moj-intranet.com/service/post/get

2. Are we happy the new api endpoint and naming is siblings? E.g.
http://www.moj-intranet.com/service/news/siblings/laa//15716

3. Should we hide the next and prev links before the links are loaded in? 


