### PR TITLE
Cookies Fix

### DIFF
--- a/wp-content/themes/mojintranet/inc/cookies.php
+++ b/wp-content/themes/mojintranet/inc/cookies.php
@@ -1,21 +1,28 @@
 <?php
 function dw_set_cache_cookie() {
-  $cookie_url = preg_replace('#^https?://#', '', get_site_url());
-
   if (current_user_can('edit_posts')) {
-    setcookie('dw_can_edit_posts', 1, time() + (7 * DAY_IN_SECONDS), COOKIEPATH, $cookie_url);
+    dw_set_edit_posts_cookie(true);
   }
   elseif (isset($_COOKIE['dw_can_edit_posts'])) {
-    setcookie('dw_can_edit_posts', 0, 1, COOKIEPATH, $cookie_url);
+    dw_set_edit_posts_cookie(false);
   }
 }
 add_action('init', 'dw_set_cache_cookie', 10, 3);
 
 function dw_set_login_cookie($user_login, $user) {
-  $cookie_url = preg_replace('#^https?://#', '', get_site_url());
-
   if(isset($user->allcaps['edit_posts']) && $user->allcaps['edit_posts'] == true) {
-    setcookie('dw_can_edit_posts', 1, time() + (7 * DAY_IN_SECONDS), COOKIEPATH, $cookie_url);
+    dw_set_edit_posts_cookie(true);
   }
 }
 add_action('wp_login', 'dw_set_login_cookie', 10, 2);
+
+function dw_set_edit_posts_cookie($active) {
+  $cookie_url = preg_replace('#^https?://#', '', get_site_url());
+
+  if ($active == true) {
+    setcookie('dw_can_edit_posts', 1, time() + (7 * DAY_IN_SECONDS), COOKIEPATH, $cookie_url);
+  }
+  else {
+    setcookie('dw_can_edit_posts', 0, 1, COOKIEPATH, $cookie_url);
+  }
+}

--- a/wp-content/themes/mojintranet/inc/cookies.php
+++ b/wp-content/themes/mojintranet/inc/cookies.php
@@ -1,10 +1,21 @@
 <?php
 function dw_set_cache_cookie() {
+  $cookie_url = preg_replace('#^https?://#', '', get_site_url());
+
   if (current_user_can('edit_posts')) {
-    setcookie('dw_can_edit_posts', 1, 7 * DAY_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN);
+    setcookie('dw_can_edit_posts', 1, time() + (7 * DAY_IN_SECONDS), COOKIEPATH, $cookie_url);
   }
   elseif (isset($_COOKIE['dw_can_edit_posts'])) {
-    setcookie('dw_can_edit_posts', 0, 1, COOKIEPATH, COOKIE_DOMAIN);
+    setcookie('dw_can_edit_posts', 0, 1, COOKIEPATH, $cookie_url);
   }
 }
 add_action('init', 'dw_set_cache_cookie', 10, 3);
+
+function dw_set_login_cookie($user_login, $user) {
+  $cookie_url = preg_replace('#^https?://#', '', get_site_url());
+
+  if(isset($user->allcaps['edit_posts']) && $user->allcaps['edit_posts'] == true) {
+    setcookie('dw_can_edit_posts', 1, time() + (7 * DAY_IN_SECONDS), COOKIEPATH, $cookie_url);
+  }
+}
+add_action('wp_login', 'dw_set_login_cookie', 10, 2);

--- a/wp-content/themes/mojintranet/inc/cookies.php
+++ b/wp-content/themes/mojintranet/inc/cookies.php
@@ -1,4 +1,11 @@
 <?php
+
+/**
+ * Check if the user has permission to edit posts, and set or delete the
+ * 'edit posts' cookie accordingly.
+ *
+ * Action: init
+ */
 function dw_set_cache_cookie() {
   if (current_user_can('edit_posts')) {
     dw_set_edit_posts_cookie(true);
@@ -7,20 +14,39 @@ function dw_set_cache_cookie() {
     dw_set_edit_posts_cookie(false);
   }
 }
-add_action('init', 'dw_set_cache_cookie', 10, 3);
+add_action('init', 'dw_set_cache_cookie', 10);
 
-function dw_set_login_cookie($user_login, $user) {
-  if(isset($user->allcaps['edit_posts']) && $user->allcaps['edit_posts'] == true) {
+/**
+ * Check if the user has permission to edit posts, and set or delete the
+ * 'edit posts' cookie accordingly.
+ *
+ * This runs after wp_login, at which point current_user_can() cannot be used.
+ *
+ * Action: wp_login
+ *
+ * @param string $user_login
+ * @param WP_User $user
+ */
+function dw_set_login_cookie($user_login, WP_User $user) {
+  if (!empty($user->allcaps['edit_posts'])) {
     dw_set_edit_posts_cookie(true);
+  }
+  else {
+    dw_set_edit_posts_cookie(false);
   }
 }
 add_action('wp_login', 'dw_set_login_cookie', 10, 2);
 
+/**
+ * Set or delete the 'edit posts' cookie.
+ *
+ * @param bool $active To set the cookie, or not to set the cookie. That is the question.
+ */
 function dw_set_edit_posts_cookie($active) {
   $cookie_url = preg_replace('#^https?://#', '', get_site_url());
 
-  if ($active == true) {
-    setcookie('dw_can_edit_posts', 1, time() + (7 * DAY_IN_SECONDS), COOKIEPATH, $cookie_url);
+  if ($active) {
+    setcookie('dw_can_edit_posts', 1, strtotime('+7 days'), COOKIEPATH, $cookie_url);
   }
   else {
     setcookie('dw_can_edit_posts', 0, 1, COOKIEPATH, $cookie_url);


### PR DESCRIPTION
The cookie was not being set. 

There was two issues. The time was off so it should of been 7 days from the current time not just 7 days.

Also the global Cookie domain was return false.

I have also added a extra hook so the cookie is created on login. Otherwise it requires an extra load of a backend page.

@ollietreend  please review

