### PR TITLE
Format ACF Dates

### DIFF
--- a/wp-content/themes/mojintranet/functions.php
+++ b/wp-content/themes/mojintranet/functions.php
@@ -28,6 +28,7 @@ require_once('inc/list-tables.php');                      // Adjustments to list
 require_once('inc/admin-commands.php');                   // Admin commands
 require_once('inc/menu-locations.php');                   // Register menu locations
 require_once('inc/option-pages.php');                     // Option Pages
+require_once('inc/event-details.php');                    // Event Detail Fields
 require_once('inc/page-options.php');                     // Page Options
 require_once('inc/query-vars.php');                       // Register custom query variables
 require_once('inc/redirects.php');                        // Site redirects

--- a/wp-content/themes/mojintranet/inc/event-details.php
+++ b/wp-content/themes/mojintranet/inc/event-details.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Formats the event date stored in the DB
+ * Filter: acf/update_value
+ *
+ * @param string $value - the value of custom field (date)
+ */
+function dw_format_event_dates($value){
+  if(strlen($value) == 8) {
+    $value = substr($value , 0, 4) . '-'. substr($value , 4, 2) . '-'. substr($value , 6, 2);
+  }
+  return $value;
+}
+add_filter('acf/update_value/key=field_57e8ead6a0890', 'dw_format_event_dates');
+add_filter('acf/update_value/key=field_57e8ec4136787', 'dw_format_event_dates');


### PR DESCRIPTION
There was a bug that events need to be formatted as YYYY-MM-DD but ACF only stores date value in the  DB format of YYYYMMDD. This meant events were not showing.

@ollietreend  please review.