### PR TITLE
Media grid firefox fix

### DIFF
--- a/wp-content/themes/mojintranet/assets/css/src/content/media_grid/_main.scss
+++ b/wp-content/themes/mojintranet/assets/css/src/content/media_grid/_main.scss
@@ -123,7 +123,7 @@
 
   .section {
     display: inline-block;
-     width:  100%;
+    width:  100%;
   }
 
 }

--- a/wp-content/themes/mojintranet/assets/css/src/ie/_media_grid.scss
+++ b/wp-content/themes/mojintranet/assets/css/src/ie/_media_grid.scss
@@ -29,6 +29,7 @@
 
   .section {
     width: 47.1%;
+    padding:0px 10px;
     display: inline-block;
     *display: inline;
     float: left;
@@ -67,5 +68,14 @@
     bottom: 5%;
     zoom: 100%;
     z-index: 10;
+  }
+
+  .section {
+    width: 47.1%;
+    padding:0px 10px;
+    display: inline-block;
+    *display: inline;
+    float: left;
+    zoom: 1;
   }
 }

--- a/wp-content/themes/mojintranet/assets/css/src/ie/_media_grid.scss
+++ b/wp-content/themes/mojintranet/assets/css/src/ie/_media_grid.scss
@@ -72,7 +72,7 @@
 
   .section {
     width: 47.1%;
-    padding:0px 10px;
+    padding:0 10px;
     display: inline-block;
     *display: inline;
     float: left;

--- a/wp-content/themes/mojintranet/assets/css/src/ie/_media_grid.scss
+++ b/wp-content/themes/mojintranet/assets/css/src/ie/_media_grid.scss
@@ -29,7 +29,7 @@
 
   .section {
     width: 47.1%;
-    padding:0px 10px;
+    padding:0 10px;
     display: inline-block;
     *display: inline;
     float: left;

--- a/wp-content/themes/mojintranet/views/pages/media_grid/quotes.php
+++ b/wp-content/themes/mojintranet/views/pages/media_grid/quotes.php
@@ -7,11 +7,11 @@
   <h3><?php echo get_sub_field('quote_section_title'); ?></h3>
   </div>
     </div>
-  <div class="grid article">
+  <div class="grid col-lg-12 col-md-12 col-sm-12 article">
   <?php $quotes = get_sub_field('quotes'); ?>
   <?php if ($quotes):
     foreach ($quotes as $quote): ?>
-    <div class="col-lg-12 col-md-12 col-sm-12 section">
+    <div class="section">
       <div class="blockquote"><p><?php echo $quote['quote_text'].'<br>'; ?></p>
       <div class="authorTitle"><p><?php echo $quote['quote_author'].'<br>'; ?></p></div></div>
     </div>


### PR DESCRIPTION
@foxleigh81 could you review?

Fixes bug that resulted in the quote section of the media grid template listing quotes in one column rather then in a masonry arrangement. 