### PR TITLE
Changes made due to users having to frequently login to comment. Set …

### DIFF
--- a/wp-content/themes/mojintranet/inc/security.php
+++ b/wp-content/themes/mojintranet/inc/security.php
@@ -43,8 +43,7 @@ add_action('login_form', 'acme_autocomplete_login_form');
 
 // Force logout after x hours
 function control_login_period( $expirein ) {
-    $hour = 3600; // 1 hour in seconds
-  return $hour*24*7; // Set to 1 week
+  return 180 * DAY_IN_SECONDS; // Cookies set to expire in 180 days.
 }
 add_filter( 'auth_cookie_expiration', 'control_login_period' );
 

--- a/wp-content/themes/mojintranet/user.php
+++ b/wp-content/themes/mojintranet/user.php
@@ -96,7 +96,7 @@ class User extends MVC_controller {
 
             wp_clear_auth_cookie();
             wp_set_current_user($user->ID);
-            wp_set_auth_cookie($user->ID);
+            wp_set_auth_cookie($user->ID, true); // Boolean when true, as it relates to commenting, sets wp cookie expiration to whatever the wordpress login defaults are set to (as of this comment 180 days - see security.php).
 
             $this->model->user->update($user->ID, array(
                   'display_name' => $display_name


### PR DESCRIPTION
…commenting cookies to adhere to whatever the Wordpress global cookie authentication expiry settings are set to. As requested, login cookies and this includes commenting, has now been set to expire in 180 days. 
@IruneItoiz could you review, thanks