### PR TITLE
Remove docker hub account requirement

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -3,7 +3,6 @@
 ## Pre-requisites
 
 * [Docker](https://www.docker.com/)
-* An account on [Docker Hub](https://hub.docker.com/)
 * A fast internet connection (for the initial download of docker images etc.)
 * Port 80 of your local machine must be available (i.e. no other webserver running)
 * MoJ network access (via a VPN is fine). See [Access Requirements](#access-requirements)
@@ -30,28 +29,11 @@ visit the following URL to get fresh values to paste into the file;
 a Mac). If you have a VM as your docker host, use its IP number, in
 place of `127.0.0.1`
 
-4. Login to docker hub
-
-This project uses some public docker images, which require a login
-to the docker hub.
-
-  `docker login`
-
-Then enter your docker ID and password.
-
-You can check whether or not you are logged in by running this;
-
-  `docker pull schickling/mailcatcher`
-
-If that works, you will get a few lines of output ending in;
-
-  `Status: Image is up to date for schickling/mailcatcher:latest`
-
-5. Run `make launch`
+4. Run `make launch`
 
 See the `Makefile` for other useful commands.
 
-6. Load the initial data into the database container
+5. Load the initial data into the database container
 
   NB: If you have done this step before, even if you rebuilt your
 database container since then, you should not have to do this step
@@ -61,12 +43,12 @@ window, run this command;
 
   `make load-db-dump`
 
-7. You should now be able to access your instance of the intranet at
+6. You should now be able to access your instance of the intranet at
    this URL;
 
   http://intranet.docker
 
-8. You can now edit files in the `./bedrock_volume` and see changes in
+7. You can now edit files in the `./bedrock_volume` and see changes in
    `intranet.docker`
 
   NB: The files in this directory are automatically installed by `grunt`


### PR DESCRIPTION
Now that we are using ministryofjustice/mailcatcher instead of
schickling/mailcatcher, it is no longer necessary to authenticate
to hub.docker.com before launching a local docker compose instance
of the intranet.