### PR TITLE
Add a script to prepare Wordpress DB for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,4 @@ debug.log
 /wp-content/plugins/regenerate-thumbnails
 /wp-content/plugins/dw-document-revisions
 /wp-content/plugins/advanced-custom-fields-pro
+docker/.env

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -24,3 +24,9 @@ db-console:
 # on the site.
 restart-yas3fs:
 	docker-compose -f docker-compose-dev.yml exec wordpress bash -c 'cd /etc/service; sv restart yas3fs'
+
+# Run the script which prepares the Wordpress container for smoke testing, by adding key
+# seed data and user accounts
+prepare-wordpress-database:
+	docker-compose -f docker-compose-dev.yml exec wordpress /utils/prepare-local-wordpress-database.rb
+

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -16,6 +16,9 @@ nuke-assets:
 load-db-dump:
 	docker-compose -f docker-compose-dev.yml exec mysql bash -c 'cat /db-dump/*.sql | mysql -u$${MYSQL_USER} -p$${MYSQL_PASSWORD} $${MYSQL_DATABASE}'
 
+db-console:
+	docker-compose -f docker-compose-dev.yml exec mysql bash -c 'mysql -u$${MYSQL_USER} -p$${MYSQL_PASSWORD} $${MYSQL_DATABASE}'
+
 # Restart the S3 filesystem in the Wordpress container. If content was missing from the S3 bucket, and
 # then added later (or added to the bucket outside of Wordpress), use this command to make it show up
 # on the site.

--- a/docker/docker-compose-dev.yml
+++ b/docker/docker-compose-dev.yml
@@ -6,6 +6,7 @@ services:
     env_file: .env
     volumes:
       - ./bedrock_volume:/bedrock
+      - ./utils:/utils
     environment:
       development: 1
       WP_ENV: development

--- a/docker/dotenv.example
+++ b/docker/dotenv.example
@@ -28,3 +28,11 @@ SNS_TOPIC=[ARN of the SNS topic for yas3fs]
 # S3 bucket, and also needs permissions on the SNS topic.
 AWS_ACCESS_KEY_ID=[IAM user access key]
 AWS_SECRET_ACCESS_KEY=[IAM user secret key]
+
+# These env vars are only required if you want to run the smoke
+# tests against a local instance of the intranet. Get these values
+# from the secrets.env file in the intranet-smoke-tests repo.
+# NB: In secrets.env, these values are wrapped in single-quotes.
+# DO NOT INCLUDE THE SINGLE QUOTES HERE.
+pass_regional=[get from intranet-smoke-tests/secrets.env]
+pass_agency_editor=[get from intranet-smoke-tests/secrets.env]

--- a/docker/utils/prepare-local-wordpress-database.rb
+++ b/docker/utils/prepare-local-wordpress-database.rb
@@ -1,0 +1,65 @@
+#!/usr/bin/env ruby
+
+# TODO: this is tightly coupled to the smoke tests, and the test data
+# they're expecting to be present. This needs to be managed, somehow.
+def main
+
+  # TODO: BEFORE COMMITING
+  # replace the passwords with ENV.fetch('something')
+  # in the docker-compose-dev.yml, set the env vars
+
+  ensure_user_exists(
+    login: 'agency_editor',
+    email: 'agency_editor@example.com',
+    role: 'agency-editor',
+    password: 'dummy-value',
+    display_name: 'Agency Editor Test'
+  )
+
+  ensure_user_exists(
+    login: 'regional',
+    email: 'regional@example.com',
+    role: 'regional-editor',
+    password: 'dummy-value',
+    display_name: 'regional'
+  )
+
+end
+
+# The smoke tests expect certain users, some of which have been created
+# in production, but with passwords that differ from those configured in
+# the smoke tests. So, delete and recreate any user accounts we depend on.
+def ensure_user_exists(params)
+  login = params.fetch(:login)
+  if user_exists?(login)
+    log("User #{login} exists. Recreating")
+    delete_user(login)
+  end
+  create_user(params) unless user_exists?(login)
+end
+
+def user_exists?(login)
+  system "cd /bedrock/web; wp --allow-root user get #{login} > /dev/null 2>&1"
+end
+
+def delete_user(login)
+  system "cd /bedrock/web; wp --allow-root user delete --yes #{login} > /dev/null 2>&1"
+end
+
+# Create a user.
+# WARNING: This will break if any of the params contain a single quote
+def create_user(params)
+  log "Creating user #{params.fetch(:login)} with role #{params.fetch(:role)}"
+  login = params.fetch(:login)
+  email = params.fetch(:email)
+  role = params.fetch(:role)
+  password = params.fetch(:password)
+  display_name = params.fetch(:display_name)
+  system "cd /bedrock/web; wp --allow-root user create #{login} #{email} --role=#{role} --user_pass='#{password}' --display_name='#{display_name}' 2>/dev/null"
+end
+
+def log(message)
+  puts [Time.now.strftime("%Y-%m-%d %H:%M:%S"), message].join(' ')
+end
+
+main

--- a/docker/utils/prepare-local-wordpress-database.rb
+++ b/docker/utils/prepare-local-wordpress-database.rb
@@ -1,18 +1,11 @@
 #!/usr/bin/env ruby
 
-# TODO: this is tightly coupled to the smoke tests, and the test data
-# they're expecting to be present. This needs to be managed, somehow.
 def main
-
-  # TODO: BEFORE COMMITING
-  # replace the passwords with ENV.fetch('something')
-  # in the docker-compose-dev.yml, set the env vars
-
   ensure_user_exists(
     login: 'agency_editor',
     email: 'agency_editor@example.com',
     role: 'agency-editor',
-    password: 'dummy-value',
+    password: ENV.fetch('pass_agency_editor'),
     display_name: 'Agency Editor Test'
   )
 
@@ -20,7 +13,7 @@ def main
     login: 'regional',
     email: 'regional@example.com',
     role: 'regional-editor',
-    password: 'dummy-value',
+    password: ENV.fetch('pass_regional'),
     display_name: 'regional'
   )
 


### PR DESCRIPTION
Use WP cli, in a ruby script, to ensure the local instance of the
Wordpress database contains the seed data required by the smoke tests.
The intention is that all developers can run the smoke tests against
their locally-running instance of the intranet, rather than depending
on the 52.demo snowflake AWS environment.

* Add entries to dotenv.example with instructions for where to find the
correct values
* Add a script to prepare the database
* Add a make target to run the script via docker compose exec